### PR TITLE
Support GPT-4 Turbo

### DIFF
--- a/src/prediction_services/api_clients/OpenAIApiClient.ts
+++ b/src/prediction_services/api_clients/OpenAIApiClient.ts
@@ -74,9 +74,6 @@ class OpenAIApiClient implements ApiClient {
         if (!this.url) {
             errors.push("OpenAI API url is not set");
         }
-        if (this.model !== "gpt-3.5-turbo") {
-            errors.push("Only gpt-3.5-turbo model is supported");
-        }
 
         if (errors.length > 0) {
             // api check is not possible without passing previous checks so return early

--- a/src/prediction_services/api_clients/OpenAIApiClient.ts
+++ b/src/prediction_services/api_clients/OpenAIApiClient.ts
@@ -74,7 +74,6 @@ class OpenAIApiClient implements ApiClient {
         if (!this.url) {
             errors.push("OpenAI API url is not set");
         }
-
         if (errors.length > 0) {
             // api check is not possible without passing previous checks so return early
             return errors;

--- a/src/settings/SettingsView.tsx
+++ b/src/settings/SettingsView.tsx
@@ -135,12 +135,12 @@ export default function SettingsView(props: IProps): React.JSX.Element {
                             "The openai model that will be queried. At the moment only gpt-3.5-turbo is supported."
                         }
                         value={settings.openAIApiSettings.model}
-                        setValue={(_: string) => {}}
+                        setValue={(value: string) => updateSettings({ openAIApiSettings: { ...settings.openAIApiSettings, model: value } })}
                         options={{
                             "gpt-3.5-turbo": "gpt-3.5-turbo",
+                            "gpt-4-1106-preview": "gpt-4-1106-preview",
                         }}
                         errorMessage={errors.get("openAIApiSettings.model")}
-                        disabled
                     />
 
                     <ConnectivityCheck key={"openai"} settings={settings} />

--- a/src/settings/SettingsView.tsx
+++ b/src/settings/SettingsView.tsx
@@ -129,17 +129,19 @@ export default function SettingsView(props: IProps): React.JSX.Element {
                             })
                         }
                     />
-                    <DropDownSettingItem
+                    <TextSettingItem
                         name={"Model"}
-                        description={
-                            "The openai model that will be queried. At the moment only gpt-3.5-turbo is supported."
-                        }
+                        description={"The OpenAI model that will be queried."}
+                        placeholder="gpt-3.5-turbo"
                         value={settings.openAIApiSettings.model}
-                        setValue={(value: string) => updateSettings({ openAIApiSettings: { ...settings.openAIApiSettings, model: value } })}
-                        options={{
-                            "gpt-3.5-turbo": "gpt-3.5-turbo",
-                            "gpt-4-1106-preview": "gpt-4-1106-preview",
-                        }}
+                        setValue={(value: string) =>
+                            updateSettings({
+                                openAIApiSettings: {
+                                    ...settings.openAIApiSettings,
+                                    model: value,
+                                }
+                            })
+                        }
                         errorMessage={errors.get("openAIApiSettings.model")}
                     />
 

--- a/src/settings/utils.ts
+++ b/src/settings/utils.ts
@@ -43,7 +43,7 @@ export function checkForErrors(settings: Settings) {
         errors.set("openAIApiSettings.key", "The API key cannot be empty!");
     }
 
-    const openaiModelOptions = ["gpt-3.5-turbo"];
+    const openaiModelOptions = ["gpt-3.5-turbo", "gpt-4-1106-preview"];
     if (
         settings.apiProvider === "openai" &&
         !openaiModelOptions.contains(settings.openAIApiSettings.model)

--- a/src/settings/utils.ts
+++ b/src/settings/utils.ts
@@ -43,14 +43,11 @@ export function checkForErrors(settings: Settings) {
         errors.set("openAIApiSettings.key", "The API key cannot be empty!");
     }
 
-    const openaiModelOptions = ["gpt-3.5-turbo", "gpt-4-1106-preview"];
     if (
         settings.apiProvider === "openai" &&
-        !openaiModelOptions.contains(settings.openAIApiSettings.model)
+        settings.openAIApiSettings.model.length === 0
     ) {
-        const options = openaiModelOptions.join(", ");
-        const message = `The model '${settings.openAIApiSettings.model}' is invalid! Select one of the following: ${options}`;
-        errors.set("openAIApiSettings.model", message);
+        errors.set("openAIApiSettings.model", "The model name cannot be empty!");
     }
 
     if (


### PR DESCRIPTION
GPT-4 Turbo is a newer model with more capability and considerably reduced cost over GPT-4 (Although still higher than GPT-3.5). In my testing, it works well for autocompletion, so I believe it should be made available as an option.