### PR TITLE
Make the api base url for openai configurable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "obsidian-copilot",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "obsidian-copilot",
-            "version": "1.0.4",
+            "version": "1.0.5",
             "license": "MIT",
             "dependencies": {
                 "handlebars": "^4.7.7",

--- a/src/settings/SettingsView.tsx
+++ b/src/settings/SettingsView.tsx
@@ -105,13 +105,19 @@ export default function SettingsView(props: IProps): React.JSX.Element {
                     <TextSettingItem
                         name={"OpenAI API URL"}
                         description={
-                            "The URL used in the requests. For the openai API this is fixed."
+                            "The URL used in the requests."
                         }
                         placeholder={"Your API URL..."}
                         value={settings.openAIApiSettings.url}
                         errorMessage={errors.get("openAIApiSettings.url")}
-                        disabled
-                        setValue={(_: string) => {}}
+                        setValue={(value: string) =>
+                            updateSettings({
+                                openAIApiSettings: {
+                                    ...settings.openAIApiSettings,
+                                    url: value,
+                                },
+                            })
+                        }
                     />
                     <TextSettingItem
                         name={"OpenAI API key"}


### PR DESCRIPTION
Just by making the base url configurable, we can encompass locally hosted llm, as they can be made compatible to OpenAI's specification via https://github.com/mudler/LocalAI.